### PR TITLE
fixed rundeck_project options

### DIFF
--- a/libraries/rundeck_project.rb
+++ b/libraries/rundeck_project.rb
@@ -25,10 +25,10 @@ class Chef
 
     attribute(:project_name, kind_of: String, default: lazy { name.split('::').last }) # This should validate for bad chars
     attribute('', template: true, default_source: 'project.properties.erb')
-    attribute(:ssh_authentication, equal_to: %{privateKey password}, default: 'privateKey')
+    attribute(:ssh_authentication, equal_to: %W{privateKey password}, default: 'privateKey')
     attribute(:ssh_key, kind_of: String, default: lazy { ::File.join(parent.path, '.ssh', 'id_rsa') })
-    attribute(:executor, equal_to: %{jsch-ssh stub}, default: 'jsch-ssh') # script-exec/copy not supported yet
-    attribute(:file_copier, equal_to: %{jsch-scp stub}, default: 'jsch-scp')
+    attribute(:executor, equal_to: %W{jsch-ssh stub}, default: 'jsch-ssh') # script-exec/copy not supported yet
+    attribute(:file_copier, equal_to: %W{jsch-scp stub}, default: 'jsch-scp')
 
     def project_path
       ::File.join(parent.path, 'projects', project_name)


### PR DESCRIPTION
```
Relevant File Content:
----------------------
/home/ubuntu/chef-solo/cookbooks-2/poise/libraries/lazy_default.rb:

 33:        extend ClassMethods
 34:
 35:        def set_or_return(symbol, arg, validation)
 36:          if validation && validation[:default].is_a?(Chef::DelayedEvaluator)
 37:            validation = validation.dup
 38:            validation[:default] = instance_eval(&validation[:default])
 39:          end
 40>>         super(symbol, arg, validation)
 41:        end
 42:      end
 43:    end
 44:  end
 45:


Running handlers:
[2015-02-03T07:02:19+00:00] ERROR: Running exception handlers
Running handlers complete
[2015-02-03T07:02:19+00:00] ERROR: Exception handlers complete
[2015-02-03T07:02:19+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
Chef Client failed. 0 resources updated in 0.918596855 seconds
[2015-02-03T07:02:19+00:00] ERROR: undefined method `join' for "privateKey password":String
[2015-02-03T07:02:20+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
