### PR TITLE
Require poise explicitly

### DIFF
--- a/libraries/rundeck.rb
+++ b/libraries/rundeck.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+require 'poise'
 class Chef
   class Resource::Rundeck < Resource
     include Poise(container: true)

--- a/libraries/rundeck.rb
+++ b/libraries/rundeck.rb
@@ -27,6 +27,7 @@ class Chef
     attribute(:version, kind_of: String, default: lazy { node['rundeck']['version'] })
     attribute(:launcher_url, kind_of: String, default: lazy { node['rundeck']['launcher_url'] })
     attribute(:service_name, kind_of: String, default: 'rundeck')
+    attribute(:use_runit, equal_to: [true, false], default: true)
     # Paths
     attribute(:path, kind_of: String, default: lazy { node['rundeck']['path'] })
     attribute(:config_path, kind_of: String, default: lazy { node['rundeck']['config_path'] })
@@ -98,7 +99,7 @@ class Chef
           create_cli_user if new_resource.create_cli_user
           write_configs
           write_ssh_key if new_resource.ssh_key
-          configure_service
+          configure_service if new_resource.use_runit
         end
       end
     end

--- a/libraries/rundeck_node_source.rb
+++ b/libraries/rundeck_node_source.rb
@@ -42,6 +42,8 @@ class Chef
     attribute(:username, kind_of: String, default: lazy { parent.parent.ssh_user })
     attribute(:manual_nodes, kind_of: Array, default: [])
 
+    provides(:rundeck_node_source_file)
+
     def path
       ::File.join(parent.project_path, 'etc', 'resources.xml')
     end
@@ -82,6 +84,8 @@ class Chef
   end
 
   class Provider::RundeckNodeSourceFile < Provider::RundeckNodeSource
+    provides(:rundeck_node_source_file)
+
     def action_enable
       converge_by("write resources.xml for Rundeck project #{new_resource.parent.project_name}") do
         notifying_block do

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,7 @@
 #
 
 name 'rundeck'
-version '99.1.26'
+version '99.1.27'
 
 maintainer 'Noah Kantrowitz'
 maintainer_email 'noah@coderanger.net'


### PR DESCRIPTION
With Chef 12.2.1, I was getting repeated errors about `Poise` being undefined, preventing workbook compilation. 

A simple `require 'poise'` fixed it up.
